### PR TITLE
[FIX] Acquire NavigationSemaphore in RemoveNavigation.RemoveAsync(IScreen)

### DIFF
--- a/Assets/Packages/Meek.NavigationStack/Runtime/Serivce/Navigation/RemoveNavigation.cs
+++ b/Assets/Packages/Meek.NavigationStack/Runtime/Serivce/Navigation/RemoveNavigation.cs
@@ -37,7 +37,15 @@ namespace Meek.NavigationStack
 
         public virtual async Task RemoveAsync(IScreen screen)
         {
-            await StackNavigationService.RemoveAsync(screen, RemoveContext);
+            await SharedSemaphore.NavigationSemaphore.WaitAsync();
+            try
+            {
+                await StackNavigationService.RemoveAsync(screen, RemoveContext);
+            }
+            finally
+            {
+                SharedSemaphore.NavigationSemaphore.Release();
+            }
         }
 
         public virtual async Task RemoveAsync(Type screenClassType)


### PR DESCRIPTION
## Summary
- `RemoveNavigation.RemoveAsync(IScreen)` was the only overload that did not acquire `SharedSemaphore.NavigationSemaphore`, causing inconsistent serialization vs the `Type` overload.
- Concurrent navigation operations could race on `StackScreenContainer._screenStack`.
- Wrap the call in the same `WaitAsync`/`Release` try/finally pattern.

Closes #17

## Test plan
- [x] Manual: Trigger `RemoveAsync(IScreen)` concurrently with `PushAsync` / `PopAsync` and verify the stack stays consistent.
- [x] Run existing tests / sample scenes to ensure no regression in single-threaded navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)